### PR TITLE
fix: when library is used in a project it will result in compilation error due to missing import

### DIFF
--- a/src/middleware.types.ts
+++ b/src/middleware.types.ts
@@ -1,5 +1,5 @@
 import * as Router from '@koa/router';
-import { ParameterizedContext } from 'koa';
+import { ParameterizedContext, Request } from 'koa';
 
 interface WithRequestBody {
   request: Request & { body: unknown };


### PR DESCRIPTION
When using the validata-koa library in a project, the project compilation fails with the message

    node_modules/validata-koa/dist/middleware.types.d.ts:4:14 - error TS2304: Cannot find name 'Request'.
    
    4     request: Request & {
                   ~~~~~~~

    
    Found 1 error in node_modules/validata-koa/dist/middleware.types.d.ts:4

    error Command failed with exit code 2.

After importing Request from Koa in this file, compilation succeeded.

Closes #14